### PR TITLE
Fix link to tutorial in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Polymer Starter Project
 
 This project includes a set of Polymer components and a starter project,
-designed to be used with the [Polymer tutorial](http://www.polymer-project.org/docs/start/tutorial/intro.html).
+designed to be used with the [Polymer tutorial](http://polymer-project.org/docs/start/tutorial/intro.html).
 
 In this tutorial, you build a simple client for `unquote`, the read-only social networking service.
 


### PR DESCRIPTION
The current link to the tutorial is invalid - http://polymer-project.org/start/tutorial/intro.html
The working one is - http://polymer-project.org/docs/start/tutorial/intro.html
