### PR TITLE
Fix broken favorite icon

### DIFF
--- a/finished/post-card.html
+++ b/finished/post-card.html
@@ -35,7 +35,7 @@
       fill: #636363;
     }
     :host([favorite]) core-icon-button {
-      fill: #da4336;
+      color: #da4336;
     }
     </style>
     <div class="card-header" layout horizontal center>


### PR DESCRIPTION
Not sure if this is ready to be merged until `core-icon` goes out in the next version. We'll need to version up the `core-icon` dir in `components/` then as well.
