### PR TITLE
Fix css specifity bug with favorite icon

### DIFF
--- a/api/posts.json
+++ b/api/posts.json
@@ -4,7 +4,7 @@
     "text" : "Have you heard about the Web Components revolution?",
     "username" : "Eric",
     "avatar" : "../images/avatar-01.svg",
-    "favorite": false
+    "favorite": true
   },
   {
     "uid": 2,

--- a/finished/post-card.html
+++ b/finished/post-card.html
@@ -34,7 +34,7 @@
       right: 3px;
       color: #636363;
     }
-    :host([favorite]) core-icon-button {
+    :host([favorite]) core-icon-button#favicon {
       color: #da4336;
     }
     </style>


### PR DESCRIPTION
If i change the first item in api/posts.json to this, where the actual change is `"favorite": true`,
the favorite icon stays the same (not changing to red) until you hover it.

```
{
  "uid": 1,
  "text" : "Have you heard about the Web Components revolution?",
  "username" : "Eric",
  "avatar" : "../images/avatar-01.svg",
  "favorite": true
}
```

Seems this selector is not working in the beginning until you hover the icon:

```
:host([favorite]) core-icon-button {
  color: #da4336;
}
```
