### PR TITLE
The broken tutorial link fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Polymer Starter Project
 
 This project includes a set of Polymer components and a starter project,
-designed to be used with the [Polymer tutorial](http://polymer-project.org/docs/start/tutorial/intro.html).
+designed to be used with the [Polymer tutorial](https://www.polymer-project.org/1.0/start/).
 
 In this tutorial, you build a simple client for `unquote`, the read-only social networking service.
 


### PR DESCRIPTION
The existing tutorial link was returning 404 page. now updated with new link
